### PR TITLE
13 allow opt ining into using shadowroot while rendering components

### DIFF
--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -1,12 +1,12 @@
 export function componentFactory(innerHTML, useShadow) {
   return class Component extends HTMLElement {
-onConnectedCallback(){
-// TODO Add loading without `ShadowRoot` with the `DurianPrimitive` class
-}
+    onConnectedCallback() {
+      // TODO Add loading without `ShadowRoot` with the `DurianPrimitive` class
+    }
 
     constructor() {
       super();
-	if(!useShadow) return; 
+      if (!useShadow) return;
       this.attachShadow({ mode: "open" });
       this.shadowRoot.innerHTML = innerHTML;
     }

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -1,7 +1,12 @@
-export function componentFactory(innerHTML) {
+export function componentFactory(innerHTML, useShadow) {
   return class Component extends HTMLElement {
+onConnectedCallback(){
+// TODO Add loading without `ShadowRoot` with the `DurianPrimitive` class
+}
+
     constructor() {
       super();
+	if(!useShadow) return; 
       this.attachShadow({ mode: "open" });
       this.shadowRoot.innerHTML = innerHTML;
     }

--- a/packages/core/src/durianComponent.js
+++ b/packages/core/src/durianComponent.js
@@ -10,7 +10,7 @@ export class DurianComponent extends HTMLElement {
     this.validateComponentAttributes();
 
     const componentHTML = this.innerHTML;
-	const useShadow = this.getAttribute("useShadow") === "true" ? true : false 
+    const useShadow = this.getAttribute("useShadow") === "true" ? true : false;
 
     customElements.define(name, componentFactory(componentHTML, useShadow));
   }

--- a/packages/core/src/durianComponent.js
+++ b/packages/core/src/durianComponent.js
@@ -10,7 +10,9 @@ export class DurianComponent extends HTMLElement {
     this.validateComponentAttributes();
 
     const componentHTML = this.innerHTML;
-    customElements.define(name, componentFactory(componentHTML));
+	const useShadow = this.getAttribute("useShadow") === "true" ? true : false 
+
+    customElements.define(name, componentFactory(componentHTML, useShadow));
   }
 
   validateComponentAttributes() {


### PR DESCRIPTION
Hello! This is the development branch of issue number #13,  this feature allows for optional usage of the shadow dom when rendering components to the screen. For more information about this feature's design, implementation and syntax, please review issue #13 as mentioned above.

Thank you!