### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Miscellaneous
 - Added and customised issue templates ([@cheng-alvin](https://github.com/cheng-alvin) in [#17](https://github.com/cheng-alvin/durian.js/pull/17))
-
+- Bumped versions for release ([@cheng-alvin](https://github.com/cheng-alvin) in [#19](https://github.com/cheng-alvin/durian.js/pull/19))
 # 24/8/2023 - Initial release 🥳
 ### `@durian.js/core` - 0.1.0
 - Added `durian-components` for dynamic content and component referencing ([@cheng-alvin](https://github.com/cheng-alvin) in [#8](https://github.com/cheng-alvin/durian.js/pull/8))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durian.js/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "./src/index.js",
   "repository": "https://github.com/cheng-alvin/durian.js.git",

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -9,7 +9,7 @@
     "build": "yarn webpack --config webpack.config.js"
   },
   "dependencies": {
-    "@durian.js/core": "^0.1.0"
+    "@durian.js/core": "^0.2.0"
   },
   "devDependencies": {
     "webpack": "^5.88.2",


### PR DESCRIPTION
Bumped version on the `@durian.js/core` package from `0.1.0` to `0.2.0` as outlined in the `CHANGELOG.md` file