### PR TITLE
Implement internal stateflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `@durian.js/core` - 0.3.0
 
 - Fixed and stabilize script execution feature ([@cheng-alvin](https://github.com/cheng-alvin) in [#20](https://github.com/cheng-alvin/durian.js/pull/20))
+- Allow component DOM functions to be exposed internally ([@cheng-alvin](https://github.com/cheng-alvin) in [#21](https://github.com/cheng-alvin/durian.js/pull/21))
 
 # 8/9/2023 - Development beta 2 🙌
 

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -5,6 +5,13 @@ export function componentFactory(innerHTML) {
 
   return class Component extends DurianPrimitive {
     main() {
+      const uuid = crypto.randomUUID();
+      window.__durianData__.componentThis[uuid] = this.shadowRoot;
+
+      this.injectJs(
+        `const component = window.__durianData__.componentThis["${uuid}"];`,
+      );
+
       this.shadowRoot.querySelectorAll("script").forEach((script) => {
         const newScript = document.createElement("script");
         [...script.attributes].forEach((attr) => {
@@ -14,6 +21,12 @@ export function componentFactory(innerHTML) {
         newScript.innerHTML = script.innerHTML;
         script.parentNode.replaceChild(newScript, script);
       });
+    }
+
+    injectJs(src) {
+      const script = document.createElement("script");
+      script.innerText = src;
+      this.shadowRoot.appendChild(script);
     }
 
     constructor() {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -5,6 +5,7 @@ export function componentFactory(innerHTML) {
 
   return class Component extends DurianPrimitive {
     main() {
+      // TODO Change variable name `componentThis`
       const uuid = crypto.randomUUID();
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -1,8 +1,10 @@
+import { DurianPrimitive } from "./durianPrimitive";
+
 export function componentFactory(innerHTML) {
   innerHTML = innerHTML.replaceAll("&lt;", "<").replaceAll("&gt;", ">");
 
-  return class Component extends HTMLElement {
-    connectedCallback() {
+  return class Component extends DurianPrimitive {
+    main() {
       this.shadowRoot.querySelectorAll("script").forEach((script) => {
         const newScript = document.createElement("script");
         [...script.attributes].forEach((attr) => {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -8,6 +8,7 @@ export function componentFactory(innerHTML) {
       const uuid = crypto.randomUUID();
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 
+      // TODO Allow only for single loop:
       this.injectJs(
         `if(!component) const component = window.__durianData__.componentThis["${uuid}"] `,
       );

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -10,11 +10,7 @@ export function componentFactory(innerHTML) {
 
       // TODO Allow only for single loop:
       this.injectJs(
-        `
-        if (!component) {
-          const component = window.__durianData__.componentThis["${uuid}"];
-        }
-        `,
+        "'use-strict'; if (typeof component === 'undefined') { const component = window.__durianData__.componentThis['${uuid}']; }",
       );
 
       this.shadowRoot.querySelectorAll("script").forEach((script) => {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -9,7 +9,7 @@ export function componentFactory(innerHTML) {
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 
       this.injectJs(
-        `const component = window.__durianData__.componentThis["${uuid}"];`,
+        `if(!component) const component = window.__durianData__.componentThis["${uuid}"] `,
       );
 
       this.shadowRoot.querySelectorAll("script").forEach((script) => {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -10,7 +10,11 @@ export function componentFactory(innerHTML) {
 
       // TODO Allow only for single loop:
       this.injectJs(
-        `if(!component) const component = window.__durianData__.componentThis["${uuid}"] `,
+        `
+        if (!component) {
+          const component = window.__durianData__.componentThis["${uuid}"];
+        }
+        `,
       );
 
       this.shadowRoot.querySelectorAll("script").forEach((script) => {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -10,7 +10,7 @@ export function componentFactory(innerHTML) {
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 
       // TODO Encapsulate to file
-      const EXPOSURE_SCRIPT = `'use-strict'; if (typeof component === 'undefined') { const component = window.__durianData__.componentThis['${uuid}']; }`;
+      const EXPOSURE_SCRIPT = `'use-strict'; const component = window.__durianData__.componentThis['${uuid}'];`;
 
       // TODO Allow only for single loop:
       this.injectJs(EXPOSURE_SCRIPT);

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -9,12 +9,15 @@ export function componentFactory(innerHTML) {
       const uuid = crypto.randomUUID();
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 
+      // TODO Encapsulate to file
+      const EXPOSURE_SCRIPT = `'use-strict'; if (typeof component === 'undefined') { const component = window.__durianData__.componentThis['${uuid}']; }`;
+
       // TODO Allow only for single loop:
-      this.injectJs(
-        "'use-strict'; if (typeof component === 'undefined') { const component = window.__durianData__.componentThis['${uuid}']; }",
-      );
+      this.injectJs(EXPOSURE_SCRIPT);
 
       this.shadowRoot.querySelectorAll("script").forEach((script) => {
+        if (script.classList.contains("durian-generated-script")) return;
+
         const newScript = document.createElement("script");
         [...script.attributes].forEach((attr) => {
           newScript.setAttribute(attr.name, attr.value);
@@ -28,7 +31,8 @@ export function componentFactory(innerHTML) {
     injectJs(src) {
       const script = document.createElement("script");
       script.innerText = src;
-      this.shadowRoot.appendChild(script);
+      script.setAttribute("class", "durian-generated-script");
+      this.shadowRoot.prepend(script);
     }
 
     constructor() {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -5,6 +5,8 @@ export function componentFactory(innerHTML) {
 
   return class Component extends DurianPrimitive {
     main() {
+      this.style = "display: block;";
+
       // TODO Change variable name `componentThis`
       const uuid = crypto.randomUUID();
       window.__durianData__.componentThis[uuid] = this.shadowRoot;

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -36,6 +36,11 @@ export default function __durian__(bypassBrowserCheck = false) {
   if (window.__durianData__.executed) return;
 
   if (!bypassBrowserCheck) {
+    if (typeof window.__durianData__ !== "undefined")
+      throw new Error(
+        "Detected data conflict in the reserved `window.__durianData__` object is already in use! Please rename the object for durian to work properly, all durian data are stored under the `window.__durianData__` object.",
+      );
+
     if (typeof window === "undefined")
       throw new Error(
         "Durian can only be used in a browser environment! Try using a bundler like `webpack` or`parcel`! We cannot find the `window` object present inside a browser's Javascript environment, make sure Javascript is allowed and enabled in your browser!",

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,7 +6,8 @@ import { DurianComponent } from "./durianComponent.js";
  *
  * @author cheng-alvin
  *
- * @global - Uses `durianExecuted` to check if the function has been executed already.
+ * @global Uses `__durianData__.executed` to check if the function has been executed already.
+ * @note All durian.js data are stored under the `window.__durianData__` object namespace.
  *
  * @param {boolean} [bypassBrowserCheck=false] - Bypasses the browser `window` checks.
  * @note Browser checks would always run when imported as a `<script>`.
@@ -32,7 +33,7 @@ import { DurianComponent } from "./durianComponent.js";
  */
 
 export default function __durian__(bypassBrowserCheck = false) {
-  if (window.durianExecuted) return;
+  if (window.__durianData__.executed) return;
 
   if (!bypassBrowserCheck) {
     if (typeof window === "undefined")
@@ -56,7 +57,7 @@ export default function __durian__(bypassBrowserCheck = false) {
   }
 
   customElements.define("durian-component", DurianComponent);
-  window.durianExecuted = true;
+  window.__durianData__.executed = true;
 }
 
 __durian__();

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -33,10 +33,10 @@ import { DurianComponent } from "./durianComponent.js";
  */
 
 export default function __durian__(bypassBrowserCheck = false) {
-  if (window.__durianData__.executed) return;
+  if (window?.__durianData__?.executed || false) return;
 
   if (!bypassBrowserCheck) {
-    if (typeof window.__durianData__ !== "undefined")
+    if (typeof window?.__durianData__ !== "undefined")
       throw new Error(
         "Detected data conflict in the reserved `window.__durianData__` object is already in use! Please rename the object for durian to work properly, all durian data are stored under the `window.__durianData__` object.",
       );

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -61,6 +61,7 @@ export default function __durian__(bypassBrowserCheck = false) {
     );
   }
 
+  window.__durianData__ = { componentThis: {} };
   customElements.define("durian-component", DurianComponent);
   window.__durianData__.executed = true;
 }


### PR DESCRIPTION
Hello there, this is a pull request for development on implementing exposure of DOM helper functions inside the `durian-component`. Contrary to the global scope, you cannot just simply use the `document` object to access the DOM helper functions such as `document.querySelector()`. I've implemented the code to inject a js script line inside the code to expose the shadow root DOM functions in `component`. So, not you can just reference `component` instead of `document` to grab stuff from the DOM tree (The shadow DOM to be specific).
