### PR TITLE
Constant encapsulation

### DIFF
--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -1,3 +1,4 @@
+// TODO Add `import` line to import `EXPOSURE_SCRIPT` from `constants.js` 
 import { DurianPrimitive } from "./durianPrimitive";
 
 export function componentFactory(innerHTML) {

--- a/packages/core/src/component.js
+++ b/packages/core/src/component.js
@@ -11,9 +11,6 @@ export function componentFactory(innerHTML) {
       const uuid = crypto.randomUUID();
       window.__durianData__.componentThis[uuid] = this.shadowRoot;
 
-      // TODO Encapsulate to file
-      const EXPOSURE_SCRIPT = `'use-strict'; const component = window.__durianData__.componentThis['${uuid}'];`;
-
       // TODO Allow only for single loop:
       this.injectJs(EXPOSURE_SCRIPT);
 

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -1,0 +1,1 @@
+export const EXPOSURE_SCRIPT = `'use-strict'; const component = window.__durianData__.componentThis['${uuid}'];`;


### PR DESCRIPTION
This is the development for the encapsulation of the constant script currently inside the source code (`EXPOSURE_SCRIPT` that exposes the DOM functions implemented in #21) This PR would just encapsulate and separate the script in another file for orginization purposes. Therefore, more scripts for attributes and even state in the furture (Potentially)  can be added without cluter to the codebase.

**Note:** The script still needs to be imported to `component.js` inorder to it to work properly, a `TODO` notice has already been added as of commit number [a2b3ecf](https://github.com/cheng-alvin/durian.js/commit/a2b3ecfaf0587dd619d15af81b9c1495af0a1794)

Thanks 